### PR TITLE
fix: possibilitar clicar atras do header

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -35,6 +35,14 @@ ul {
   padding: 4px 6px;
 }
 
+header#cabecalho {
+  pointer-events: none;
+}
+
+header#cabecalho *:not(nav, div, ul) {
+  pointer-events: auto;
+}
+
 header#cabecalho nav ul li {
   width: 208px;
 }


### PR DESCRIPTION
No arquivo "global.css", coloquei "points-event: none" para o cabeçalho, e "points-event: auto" para os que não forem:  [nav, div, ul]